### PR TITLE
[MINSTALL-115] installAtEnd fails with multiple class realms

### DIFF
--- a/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
@@ -67,8 +67,17 @@ public class InstallMojo
     private List<MavenProject> reactorProjects;
 
     /**
-     * Whether every project should be installed during its own install-phase or at the end of the multimodule build. If
-     * set to {@code true} and the build fails, none of the reactor projects is installed.
+     * Whether every project should be installed during its own install-phase or at the end of the
+     * multi-module build. If set to {@code true} and the build fails, none of the reactor projects
+     * is installed.
+     *
+     * In order for this flag to work properly, all modules of the multi-module must set this
+     * property to the same value and all modules must have the same value for the skip property.
+     * If this property or the skip property are inconsistently set in different projects, any
+     * project with this property set to true will not be installed either immediately nor at the
+     * end of the build.  See details in
+     * <a href="https://issues.apache.org/jira/browse/MINSTALL-115">MINSTALL-115</a>
+     *
      * <strong>(experimental)</strong>
      * 
      * @since 2.5

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -34,5 +34,22 @@ under the License.
        </p>
      </answer>
    </faq>
+   <faq id="question">
+     <question>Why isn't <i>installAtEnd</i> property working?</question>
+     <answer>
+       <p>
+       The <i>installAtEnd</i> property must be set consistently in all modules and the <i>skip</i>
+       property must be set consistently in all modules.  If either property is not consistent, any
+       module with <i>installAtEnd</i> set to true will not be installed.
+       </p>
+       <p>
+       An alternative to using <i>installAtEnd</i> is to have the build script invoke Maven twice:
+<pre>
+ mvn verify
+ mvn install:install
+</pre>
+       </p>
+     </answer>
+   </faq>
  </part>
 </faqs>


### PR DESCRIPTION
Setting installAtEnd causes no installs to occur when a multimodule project has multiple class realms