### PR TITLE
[MINSTALL-148] - Document change about createChecksums

### DIFF
--- a/src/site/apt/examples/installing-checksums.apt.vm
+++ b/src/site/apt/examples/installing-checksums.apt.vm
@@ -1,0 +1,34 @@
+  ------
+  Creating Checksums (removed since 3.0.0+)
+  ------
+  Vincent Siveton
+  Robert Scholte
+  ------
+  2018-10-10
+  ------
+
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~   http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+~~ NOTE: For help with the syntax of this file, see:
+~~ http://maven.apache.org/doxia/references/apt-format.html
+
+Creating Checksums (removed since 3.0.0+)
+
+  <<Note>>:
+      From Version 3.0.0 the Install Plugin goal does not support creating checksums anymore.
+      Details can be found in {{{https://issues.apache.org/jira/browse/MINSTALL-143}MINSTALL-143}}.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -34,6 +34,7 @@ under the License.
     </menu>
     <menu name="Examples">
       <item name="Installing Artifact with Custom POM" href="examples/custom-pom-installation.html"/>
+      <item name="Creating Checksums" href="examples/installing-checksums.html"/>
       <item name="Generating Generic POM" href="examples/generic-pom-generation.html"/>
       <item name="Updating Release Info" href="examples/update-release-info.html"/>
       <item name="Installing to a Specific Local Repository Path" href="examples/specific-local-repo.html"/>


### PR DESCRIPTION
Document the removal of checksum in install plugin.
I was looking for checksum generation because my problem with checksum Policy failure, seeing https://maven.apache.org/plugins/maven-install-plugin/examples/installing-checksums.html confused me more.
I think it's better to leave a note here and point people to the right direction if they are looking for checksum generation is better:
<img width="1174" alt="screen shot 2018-10-10 at 3 22 33 am" src="https://user-images.githubusercontent.com/5586453/46683549-39863180-cc3c-11e8-9185-007ec8df664a.png">
