### PR TITLE
Minor improvement to English grammar in error msg

### DIFF
--- a/src/main/java/org/apache/maven/plugins/install/InstallFileMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallFileMojo.java
@@ -185,7 +185,7 @@ public class InstallFileMojo
 
         if ( !file.exists() )
         {
-            String message = "The specified file '" + file.getPath() + "' not exists";
+            String message = "The specified file '" + file.getPath() + "' does not exist";
             getLog().error( message );
             throw new MojoFailureException( message );
         }


### PR DESCRIPTION
Fixed some unusual phrasing I saw while running maven commands.
Goal is to leave things even better than I found them :)


**From the automatic checklist:**
"Trivial changes like typos do not  require a JIRA issue."
"If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list."

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

