### PR TITLE
Install At End, Variant 2

### DIFF
--- a/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
@@ -325,6 +325,7 @@ public class InstallMojoTest
         MavenProject project = (MavenProject) getVariableValueFromObject( mojo, "project" );
         updateMavenProject( project );
 
+        setVariableValueToObject( mojo, "pluginContext", new ConcurrentHashMap<>() );
         setVariableValueToObject( mojo, "pluginDescriptor", new PluginDescriptor() );
         setVariableValueToObject( mojo, "reactorProjects", Collections.singletonList( project ) );
         setVariableValueToObject( mojo, "session", createMavenSession() );


### PR DESCRIPTION
This PR is inspired by original "installAtEnd" feature,
but does not need to be run as extension.

In short, it uses plugin contexts of reactor
sorted projects to store state in.

This is **much simpler and my preferred solution**.

Also, plugin is updated, org.sonatype.aether removed.
