### PR TITLE
[MINSTALL-160] Generated POM is not installed if original POM exists

### DIFF
--- a/src/it/MINSTALL-52/verify.groovy
+++ b/src/it/MINSTALL-52/verify.groovy
@@ -22,4 +22,5 @@ assert new File( basedir, "../../local-repo/org/apache/maven/plugins/install/its
 
 File buildLog = new File( basedir, 'build.log' )
 assert buildLog.exists()
-assert buildLog.text.contains( "[DEBUG] Using META-INF/maven/org.apache.maven.plugins.install.its/minstall52/pom.xml as pomFile" )
+assert buildLog.text.contains( "[DEBUG] Loading META-INF/maven/org.apache.maven.plugins.install.its/minstall52/pom.xml" )
+assert buildLog.text.contains( "[DEBUG] Using JAR embedded POM as pomFile" )

--- a/src/main/java/org/apache/maven/plugins/install/InstallFileMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallFileMojo.java
@@ -206,6 +206,11 @@ public class InstallFileMojo
         else
         {
             temporaryPom = readingPomFromJarFile();
+            if ( !Boolean.TRUE.equals( generatePom ) )
+            {
+                pomFile = temporaryPom;
+                getLog().debug( "Using JAR embedded POM as pomFile" );
+            }
         }
 
         if ( groupId == null || artifactId == null || version == null || packaging == null )
@@ -321,7 +326,7 @@ public class InstallFileMojo
 
                 if ( pomEntry.matcher( entry.getName() ).matches() )
                 {
-                    getLog().debug( "Using " + entry.getName() + " as pomFile" );
+                    getLog().debug( "Loading " + entry.getName() );
 
                     InputStream pomInputStream = null;
                     OutputStream pomOutputStream = null;

--- a/src/main/java/org/apache/maven/plugins/install/InstallFileMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallFileMojo.java
@@ -206,7 +206,6 @@ public class InstallFileMojo
         else
         {
             temporaryPom = readingPomFromJarFile();
-            pomFile = temporaryPom;
         }
 
         if ( groupId == null || artifactId == null || version == null || packaging == null )

--- a/src/test/java/org/apache/maven/plugins/install/InstallFileMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/install/InstallFileMojoTest.java
@@ -92,9 +92,6 @@ public class InstallFileMojoTest
         assignValuesForParameter( mojo );
 
         mojo.execute();
-        
-        File pomFile = (File) getVariableValueFromObject( mojo, "pomFile" );
-        org.codehaus.plexus.util.FileUtils.forceDelete( pomFile );
 
         File installedArtifact = new File( getBasedir(), LOCAL_REPO + groupId + "/" + artifactId + "/" + version + "/" +
             artifactId + "-" + version + "." + packaging );
@@ -121,9 +118,6 @@ public class InstallFileMojoTest
         assertNotNull( classifier );
 
         mojo.execute();
-
-        File pomFile = (File) getVariableValueFromObject( mojo, "pomFile" );
-        org.codehaus.plexus.util.FileUtils.forceDelete( pomFile );
 
         File installedArtifact = new File( getBasedir(), LOCAL_REPO + groupId + "/" + artifactId + "/" + version + "/" +
             artifactId + "-" + version + "-" + classifier + "." + packaging );


### PR DESCRIPTION
When using `generatePom=true` with install-file Mojo, it will despite
this copy existing POM if it is found embedded in JAR (and if it
was built with Maven, it will find it).

The generatePom should reuse POM values embedded from JAR
but should generate (and install) new "empty POM" instead.

---

https://issues.apache.org/jira/browse/MINSTALL-160

