### PR TITLE
[MINSTALL-179] Fix installAtEnd when module does not use m-install-p

### DIFF
--- a/src/it/install-at-end-pass/module2/pom.xml
+++ b/src/it/install-at-end-pass/module2/pom.xml
@@ -20,5 +20,20 @@
     <artifactId>dae</artifactId>
     <version>1.0</version>
   </parent>
-  <artifactId>module1</artifactId>
+  <artifactId>module2</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-install</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/it/install-at-end-pass/module3/pom.xml
+++ b/src/it/install-at-end-pass/module3/pom.xml
@@ -20,5 +20,5 @@
     <artifactId>dae</artifactId>
     <version>1.0</version>
   </parent>
-  <artifactId>module1</artifactId>
+  <artifactId>module3</artifactId>
 </project>

--- a/src/it/install-at-end-pass/module4/pom.xml
+++ b/src/it/install-at-end-pass/module4/pom.xml
@@ -20,5 +20,19 @@
     <artifactId>dae</artifactId>
     <version>1.0</version>
   </parent>
-  <artifactId>module1</artifactId>
+  <artifactId>module4</artifactId>
+
+  <!-- packaging without install plugin -->
+  <packaging>without-install</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.install.mock</groupId>
+        <artifactId>mock-phase-maven-plugin</artifactId>
+        <version>1.0</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/it/install-at-end-pass/pom.xml
+++ b/src/it/install-at-end-pass/pom.xml
@@ -71,6 +71,9 @@ under the License.
 
   <modules>
     <module>module1</module>
+    <module>module2</module>
+    <module>module3</module>
+    <module>module4</module>
   </modules>
 
 </project>

--- a/src/it/install-at-end-pass/verify.groovy
+++ b/src/it/install-at-end-pass/verify.groovy
@@ -19,8 +19,11 @@
 
 assert new File( basedir, "../../local-repo/org/apache/maven/its/install/dae/pass/dae/1.0/dae-1.0.pom" ).exists()
 assert new File( basedir, "../../local-repo/org/apache/maven/its/install/dae/pass/module1/1.0/module1-1.0.pom" ).exists()
+assert new File( basedir, "../../local-repo/org/apache/maven/its/install/dae/pass/module3/1.0/module3-1.0.pom" ).exists()
 
 File buildLog = new File( basedir, 'build.log' )
 assert buildLog.exists()
 assert buildLog.text.contains( "[INFO] Deferring install for org.apache.maven.its.install.dae.pass:dae:1.0 at end" )
+assert buildLog.text.contains( "[INFO] Deferring install for org.apache.maven.its.install.dae.pass:module1:1.0 at end" )
+assert buildLog.text.contains( "[INFO] Deferring install for org.apache.maven.its.install.dae.pass:module3:1.0 at end" )
 

--- a/src/it/setup-mock-phase-maven-plugin/invoker.properties
+++ b/src/it/setup-mock-phase-maven-plugin/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = install

--- a/src/it/setup-mock-phase-maven-plugin/pom.xml
+++ b/src/it/setup-mock-phase-maven-plugin/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.install.mock</groupId>
+  <artifactId>mock-phase-maven-plugin</artifactId>
+  <version>1.0</version>
+  <packaging>maven-plugin</packaging>
+
+  <prerequisites>
+    <maven>@mavenVersion@</maven>
+  </prerequisites>
+
+  <description>plugin with Maven phase without m-install-p</description>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>@project.version@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>3.6.4</version>
+          <configuration>
+            <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/src/it/setup-mock-phase-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/src/it/setup-mock-phase-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<component-set>
+  <components>
+    <component>
+      <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+      <role-hint>without-install</role-hint>
+      <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+      <configuration>
+        <lifecycles>
+          <lifecycle>
+            <id>default</id>
+            <phases>
+              <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
+            </phases>
+          </lifecycle>
+        </lifecycles>
+      </configuration>
+    </component>
+  </components>
+</component-set>

--- a/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
@@ -19,10 +19,6 @@ package org.apache.maven.plugins.install;
  * under the License.
  */
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -31,8 +27,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.metadata.ArtifactMetadata;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
@@ -48,10 +45,13 @@ import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 /**
  * @author <a href="mailto:aramirez@apache.org">Allan Ramirez</a>
  */
-
 public class InstallMojoTest
     extends AbstractMojoTestCase
 {
@@ -381,5 +381,10 @@ public class InstallMojoTest
        project.setGroupId( project.getArtifact().getGroupId() );
        project.setArtifactId( project.getArtifact().getArtifactId() );
        project.setVersion( project.getArtifact().getVersion() );
+
+       Plugin plugin = new Plugin();
+       plugin.setArtifactId( "maven-install-plugin" );
+       project.setBuild( new Build() );
+       project.getBuild().addPlugin( plugin );
     }
 }


### PR DESCRIPTION
Example fix for installAtEnd when build contains module that does NOT use m-install-p. Very same fix  can go to m-deploy-p.

Side-effect: installAtEnd means "install at last m-install-p invocation", and not "at build end". This is acceptable IMHO as we talk about very little subset or projects, as majority does not suffer from this.