### PR TITLE
[MINSTALL-197] Update to parent 41, cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-plugins</artifactId>
-    <version>39</version>
+    <version>41</version>
     <relativePath />
   </parent>
 
@@ -46,7 +46,7 @@
   </contributors>
 
   <prerequisites>
-    <maven>${mavenVersion}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <scm>
@@ -72,21 +72,21 @@
 
   <properties>
     <javaVersion>8</javaVersion>
-    <mavenVersion>3.2.5</mavenVersion>
+    <mavenVersion>3.9.6</mavenVersion>
     <!-- Maven bound -->
-    <aetherVersion>1.0.0.v20140518</aetherVersion>
+    <resolverVersion>1.9.18</resolverVersion>
     <!-- Maven bound -->
-    <slf4jVersion>1.7.5</slf4jVersion>
+    <slf4jVersion>1.7.36</slf4jVersion>
 
     <!-- plugin versions used in IT tests -->
     <mavenAntrunPluginVersion>3.1.0</mavenAntrunPluginVersion>
-    <mavenCompilerPluginVersion>3.10.1</mavenCompilerPluginVersion>
-    <mavenEnforcerPluginVersion>3.1.0</mavenEnforcerPluginVersion>
+    <mavenCompilerPluginVersion>3.12.1</mavenCompilerPluginVersion>
+    <mavenEnforcerPluginVersion>3.4.1</mavenEnforcerPluginVersion>
     <mavenJarPluginVersion>3.3.0</mavenJarPluginVersion>
-    <mavenPluginPluginVersion>3.7.0</mavenPluginPluginVersion>
+    <mavenPluginPluginVersion>3.11.0</mavenPluginPluginVersion>
     <mavenResourcesPluginVersion>3.3.0</mavenResourcesPluginVersion>
     <mavenSourcePluginVersion>3.2.1</mavenSourcePluginVersion>
-    <mavenSurefirePluginVersion>3.0.0-M7</mavenSurefirePluginVersion>
+    <mavenSurefirePluginVersion>3.2.5</mavenSurefirePluginVersion>
 
     <project.build.outputTimestamp>2023-03-21T14:31:18Z</project.build.outputTimestamp>
   </properties>
@@ -118,21 +118,25 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
-      <version>${aetherVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>${resolverVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
-      <version>${aetherVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <version>${resolverVersion}</version>
       <!-- To work in Maven versions older than 3.9.0 -->
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
     </dependency>
 
     <!-- dependencies to annotations -->
@@ -180,12 +184,25 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
-      <version>${aetherVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
+      <version>${resolverVersion}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <proc>none</proc>
+          <showDeprecation>true</showDeprecation>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   </contributors>
 
   <prerequisites>
-    <maven>3.6.3</maven>
+    <maven>3.2.5</maven>
   </prerequisites>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -79,14 +79,14 @@
     <slf4jVersion>1.7.36</slf4jVersion>
 
     <!-- plugin versions used in IT tests -->
-    <mavenAntrunPluginVersion>3.1.0</mavenAntrunPluginVersion>
-    <mavenCompilerPluginVersion>3.12.1</mavenCompilerPluginVersion>
-    <mavenEnforcerPluginVersion>3.4.1</mavenEnforcerPluginVersion>
-    <mavenJarPluginVersion>3.3.0</mavenJarPluginVersion>
-    <mavenPluginPluginVersion>3.11.0</mavenPluginPluginVersion>
-    <mavenResourcesPluginVersion>3.3.0</mavenResourcesPluginVersion>
-    <mavenSourcePluginVersion>3.2.1</mavenSourcePluginVersion>
-    <mavenSurefirePluginVersion>3.2.5</mavenSurefirePluginVersion>
+    <mavenAntrunPluginVersion>${version.maven-antrun-plugin}</mavenAntrunPluginVersion>
+    <mavenCompilerPluginVersion>${version.maven-compiler-plugin}</mavenCompilerPluginVersion>
+    <mavenEnforcerPluginVersion>${version.maven-enforcer-plugin}</mavenEnforcerPluginVersion>
+    <mavenJarPluginVersion>${version.maven-jar-plugin}</mavenJarPluginVersion>
+    <mavenPluginPluginVersion>${version.maven-plugin-tools}</mavenPluginPluginVersion>
+    <mavenResourcesPluginVersion>${version.maven-resources-plugin}</mavenResourcesPluginVersion>
+    <mavenSourcePluginVersion>${version.maven-source-plugin}</mavenSourcePluginVersion>
+    <mavenSurefirePluginVersion>${version.maven-surefire}</mavenSurefirePluginVersion>
 
     <project.build.outputTimestamp>2023-03-21T14:31:18Z</project.build.outputTimestamp>
   </properties>

--- a/src/main/java/org/apache/maven/plugins/install/InstallFileMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallFileMojo.java
@@ -67,7 +67,7 @@ import static java.util.Objects.nonNull;
  */
 @Mojo(name = "install-file", requiresProject = false, aggregator = true, threadSafe = true)
 public class InstallFileMojo extends AbstractMojo {
-    private static final String LS = System.getProperty("line.separator");
+    private static final String LS = System.lineSeparator();
 
     @Component
     private RepositorySystem repositorySystem;
@@ -384,11 +384,11 @@ public class InstallFileMojo extends AbstractMojo {
     private File generatePomFile() throws MojoExecutionException {
         Model model = generateModel();
         try {
-            File tempPomFile = File.createTempFile("mvninstall", ".pom");
+            Path tempPomFile = Files.createTempFile("mvninstall", ".pom");
 
-            try (OutputStream writer = Files.newOutputStream(tempPomFile.toPath())) {
+            try (OutputStream writer = Files.newOutputStream(tempPomFile)) {
                 new MavenXpp3Writer().write(writer, model);
-                return tempPomFile;
+                return tempPomFile.toFile();
             }
         } catch (IOException e) {
             throw new MojoExecutionException("Error writing temporary POM file: " + e.getMessage(), e);

--- a/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
@@ -196,12 +196,13 @@ public class InstallMojo extends AbstractMojo {
         // incomplete project: is not pom project and projectArtifact has no file
 
         // we must compare coordinates ONLY (as projectArtifact may not have file, and Artifact.equals factors it in)
-        boolean pomArtifactIsMainArtifact = ArtifactIdUtils.equalsId(pomArtifact, projectArtifact);
-        if (pomArtifactIsMainArtifact) {
+        // BUT if projectArtifact has file set, use that one
+        if (ArtifactIdUtils.equalsId(pomArtifact, projectArtifact)) {
+            if (isFile(projectArtifact.getFile())) {
+                pomArtifact = projectArtifact;
+            }
             projectArtifact = null;
         }
-        // is not packaged, is "incomplete"
-        boolean isIncomplete = projectArtifact != null && !isFile(projectArtifact.getFile());
 
         if (isFile(pomArtifact.getFile())) {
             request.addArtifact(pomArtifact);
@@ -209,6 +210,8 @@ public class InstallMojo extends AbstractMojo {
             throw new MojoExecutionException("The project POM could not be attached");
         }
 
+        // is not packaged, is "incomplete"
+        boolean isIncomplete = projectArtifact != null && !isFile(projectArtifact.getFile());
         if (projectArtifact != null) {
             if (!isIncomplete) {
                 request.addArtifact(projectArtifact);

--- a/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
@@ -195,8 +195,7 @@ public class InstallMojo extends AbstractMojo {
         // jar project: pomArtifact and projectArtifact are DIFFERENT
         // incomplete project: is not pom project and projectArtifact has no file
 
-        // we must compare coordinates ONLY (as projectArtifact may not have file set, and Artifact.equals factors in
-        // file)
+        // we must compare coordinates ONLY (as projectArtifact may not have file, and Artifact.equals factors it in)
         boolean pomArtifactIsMainArtifact = ArtifactIdUtils.equalsId(pomArtifact, projectArtifact);
         if (pomArtifactIsMainArtifact) {
             projectArtifact = null;

--- a/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
@@ -54,10 +54,10 @@ public class InstallMojo extends AbstractMojo {
     @Component
     private RepositorySystem repositorySystem;
 
-    @Component
+    @Parameter(defaultValue = "${session}", required = true, readonly = true)
     private MavenSession session;
 
-    @Component
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
     @Parameter(defaultValue = "${plugin}", required = true, readonly = true)

--- a/src/test/java/org/apache/maven/plugins/install/InstallFileMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/install/InstallFileMojoTest.java
@@ -30,6 +30,9 @@ import org.apache.maven.project.ProjectBuildingRequest;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
+import org.eclipse.aether.internal.impl.DefaultLocalPathPrefixComposerFactory;
+import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
 import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
@@ -341,7 +344,10 @@ public class InstallFileMojoTest extends AbstractMojoTestCase {
     private MavenSession createMavenSession(String localRepositoryBaseDir) throws NoLocalRepositoryManagerException {
         MavenSession session = mock(MavenSession.class);
         DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager(new EnhancedLocalRepositoryManagerFactory()
+        repositorySession.setLocalRepositoryManager(new EnhancedLocalRepositoryManagerFactory(
+                        new DefaultLocalPathComposer(),
+                        new DefaultTrackingFileManager(),
+                        new DefaultLocalPathPrefixComposerFactory())
                 .newInstance(repositorySession, new LocalRepository(localRepositoryBaseDir)));
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
         buildingRequest.setRepositorySession(repositorySession);

--- a/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
@@ -87,10 +87,11 @@ public class InstallMojoTest extends AbstractMojoTestCase {
         MavenProject project = (MavenProject) getVariableValueFromObject(mojo, "project");
         updateMavenProject(project);
 
+        MavenSession session = createMavenSession();
+        session.setProjects(Collections.singletonList(project));
+        setVariableValueToObject(mojo, "session", session);
         setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
         setVariableValueToObject(mojo, "pluginDescriptor", new PluginDescriptor());
-        setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
-        setVariableValueToObject(mojo, "session", createMavenSession());
 
         artifact = (InstallArtifactStub) project.getArtifact();
 
@@ -123,10 +124,11 @@ public class InstallMojoTest extends AbstractMojoTestCase {
         MavenProject project = (MavenProject) getVariableValueFromObject(mojo, "project");
         updateMavenProject(project);
 
+        MavenSession session = createMavenSession();
+        session.setProjects(Collections.singletonList(project));
+        setVariableValueToObject(mojo, "session", session);
         setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
         setVariableValueToObject(mojo, "pluginDescriptor", new PluginDescriptor());
-        setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
-        setVariableValueToObject(mojo, "session", createMavenSession());
 
         List<Artifact> attachedArtifacts = project.getAttachedArtifacts();
 
@@ -167,10 +169,11 @@ public class InstallMojoTest extends AbstractMojoTestCase {
         MavenProject project = (MavenProject) getVariableValueFromObject(mojo, "project");
         updateMavenProject(project);
 
+        MavenSession session = createMavenSession();
+        session.setProjects(Collections.singletonList(project));
+        setVariableValueToObject(mojo, "session", session);
         setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
         setVariableValueToObject(mojo, "pluginDescriptor", new PluginDescriptor());
-        setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
-        setVariableValueToObject(mojo, "session", createMavenSession());
 
         artifact = (InstallArtifactStub) project.getArtifact();
 
@@ -193,10 +196,11 @@ public class InstallMojoTest extends AbstractMojoTestCase {
         MavenProject project = (MavenProject) getVariableValueFromObject(mojo, "project");
         updateMavenProject(project);
 
+        MavenSession session = createMavenSession();
+        session.setProjects(Collections.singletonList(project));
+        setVariableValueToObject(mojo, "session", session);
         setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
         setVariableValueToObject(mojo, "pluginDescriptor", new PluginDescriptor());
-        setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
-        setVariableValueToObject(mojo, "session", createMavenSession());
 
         artifact = (InstallArtifactStub) project.getArtifact();
 
@@ -226,10 +230,11 @@ public class InstallMojoTest extends AbstractMojoTestCase {
         MavenProject project = (MavenProject) getVariableValueFromObject(mojo, "project");
         updateMavenProject(project);
 
+        MavenSession session = createMavenSession();
+        session.setProjects(Collections.singletonList(project));
+        setVariableValueToObject(mojo, "session", session);
         setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
         setVariableValueToObject(mojo, "pluginDescriptor", new PluginDescriptor());
-        setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
-        setVariableValueToObject(mojo, "session", createMavenSession());
 
         String packaging = project.getPackaging();
 
@@ -264,10 +269,11 @@ public class InstallMojoTest extends AbstractMojoTestCase {
         MavenSession mavenSession = createMavenSession();
         updateMavenProject(project);
 
+        MavenSession session = createMavenSession();
+        session.setProjects(Collections.singletonList(project));
+        setVariableValueToObject(mojo, "session", session);
         setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
         setVariableValueToObject(mojo, "pluginDescriptor", new PluginDescriptor());
-        setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
-        setVariableValueToObject(mojo, "session", mavenSession);
 
         artifact = (InstallArtifactStub) project.getArtifact();
 
@@ -311,10 +317,11 @@ public class InstallMojoTest extends AbstractMojoTestCase {
         MavenProject project = (MavenProject) getVariableValueFromObject(mojo, "project");
         updateMavenProject(project);
 
+        MavenSession session = createMavenSession();
+        session.setProjects(Collections.singletonList(project));
+        setVariableValueToObject(mojo, "session", session);
         setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
         setVariableValueToObject(mojo, "pluginDescriptor", new PluginDescriptor());
-        setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
-        setVariableValueToObject(mojo, "session", createMavenSession());
         setVariableValueToObject(mojo, "skip", Boolean.TRUE);
 
         artifact = (InstallArtifactStub) project.getArtifact();

--- a/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
@@ -256,6 +256,43 @@ public class InstallMojoTest extends AbstractMojoTestCase {
         assertEquals(4, FileUtils.getFiles(new File(LOCAL_REPO), null, null).size());
     }
 
+    public void testInstallIfPackagingIsBom() throws Exception {
+        File testPom = new File(
+                getBasedir(), "target/test-classes/unit/basic-install-test-packaging-bom/" + "plugin-config.xml");
+
+        AbstractMojo mojo = (AbstractMojo) lookupMojo("install", testPom);
+
+        assertNotNull(mojo);
+
+        MavenProject project = (MavenProject) getVariableValueFromObject(mojo, "project");
+        updateMavenProject(project);
+
+        MavenSession session = createMavenSession();
+        session.setProjects(Collections.singletonList(project));
+        setVariableValueToObject(mojo, "session", session);
+        setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
+        setVariableValueToObject(mojo, "pluginDescriptor", new PluginDescriptor());
+
+        String packaging = project.getPackaging();
+
+        assertEquals("bom", packaging);
+
+        artifact = (InstallArtifactStub) project.getArtifact();
+
+        mojo.execute();
+
+        String groupId = dotToSlashReplacer(artifact.getGroupId());
+
+        File installedArtifact = new File(
+                getBasedir(),
+                LOCAL_REPO + groupId + "/" + artifact.getArtifactId() + "/" + artifact.getVersion() + "/"
+                        + artifact.getArtifactId() + "-" + artifact.getVersion() + "." + "pom");
+
+        assertTrue(installedArtifact.exists());
+
+        assertEquals(4, FileUtils.getFiles(new File(LOCAL_REPO), null, null).size());
+    }
+
     public void testBasicInstallAndCreate() throws Exception {
         File testPom = new File(getBasedir(), "target/test-classes/unit/basic-install-checksum/plugin-config.xml");
 

--- a/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
@@ -39,6 +39,9 @@ import org.apache.maven.project.ProjectBuildingRequest;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
+import org.eclipse.aether.internal.impl.DefaultLocalPathPrefixComposerFactory;
+import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
 import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
@@ -341,7 +344,10 @@ public class InstallMojoTest extends AbstractMojoTestCase {
     private MavenSession createMavenSession() throws NoLocalRepositoryManagerException {
         MavenSession session = mock(MavenSession.class);
         DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager(new EnhancedLocalRepositoryManagerFactory()
+        repositorySession.setLocalRepositoryManager(new EnhancedLocalRepositoryManagerFactory(
+                        new DefaultLocalPathComposer(),
+                        new DefaultTrackingFileManager(),
+                        new DefaultLocalPathPrefixComposerFactory())
                 .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
         buildingRequest.setRepositorySession(repositorySession);

--- a/src/test/java/org/apache/maven/plugins/install/stubs/InstallArtifactStub.java
+++ b/src/test/java/org/apache/maven/plugins/install/stubs/InstallArtifactStub.java
@@ -74,7 +74,7 @@ public class InstallArtifactStub extends ArtifactStub {
 
     public void addMetadata(ArtifactMetadata metadata) {
         if (metadataMap == null) {
-            metadataMap = new HashMap<Object, ArtifactMetadata>();
+            metadataMap = new HashMap<>();
         }
 
         ArtifactMetadata m = metadataMap.get(metadata.getKey());
@@ -85,8 +85,8 @@ public class InstallArtifactStub extends ArtifactStub {
         }
     }
 
-    public Collection getMetadataList() {
-        return metadataMap == null ? Collections.EMPTY_LIST : metadataMap.values();
+    public Collection<ArtifactMetadata> getMetadataList() {
+        return metadataMap == null ? Collections.emptyList() : metadataMap.values();
     }
 
     public boolean isRelease() {

--- a/src/test/java/org/apache/maven/plugins/install/stubs/InstallBomArtifactStub.java
+++ b/src/test/java/org/apache/maven/plugins/install/stubs/InstallBomArtifactStub.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.install.stubs;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+
+public class InstallBomArtifactStub extends InstallArtifactStub {
+
+    public String getType() {
+        return "bom";
+    }
+
+    public ArtifactHandler getArtifactHandler() {
+        return new DefaultArtifactHandler() {
+            public String getExtension() {
+                return "pom";
+            }
+        };
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/install/stubs/InstallPomArtifactStub.java
+++ b/src/test/java/org/apache/maven/plugins/install/stubs/InstallPomArtifactStub.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.install.stubs;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+
+public class InstallPomArtifactStub extends InstallArtifactStub {
+
+    public String getType() {
+        return "pom";
+    }
+
+    public ArtifactHandler getArtifactHandler() {
+        return new DefaultArtifactHandler() {
+            public String getExtension() {
+                return "pom";
+            }
+        };
+    }
+}

--- a/src/test/resources/unit/basic-install-test-packaging-bom/plugin-config.xml
+++ b/src/test/resources/unit/basic-install-test-packaging-bom/plugin-config.xml
@@ -1,0 +1,35 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <project implementation="org.apache.maven.plugin.testing.stubs.MavenProjectStub">
+            <file>${basedir}/src/test/resources/unit/basic-install-test-packaging-pom/plugin-config.xml</file>
+            <packaging>bom</packaging>
+            <artifact implementation="org.apache.maven.plugins.install.stubs.InstallBomArtifactStub"/>
+            <attachedArtifacts/>
+          </project>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/basic-install-test-packaging-bom/plugin-config.xml
+++ b/src/test/resources/unit/basic-install-test-packaging-bom/plugin-config.xml
@@ -23,7 +23,7 @@ under the License.
         <artifactId>maven-install-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugin.testing.stubs.MavenProjectStub">
-            <file>${basedir}/src/test/resources/unit/basic-install-test-packaging-pom/plugin-config.xml</file>
+            <file>${basedir}/src/test/resources/unit/basic-install-test-packaging-bom/plugin-config.xml</file>
             <packaging>bom</packaging>
             <artifact implementation="org.apache.maven.plugins.install.stubs.InstallBomArtifactStub"/>
             <attachedArtifacts/>

--- a/src/test/resources/unit/basic-install-test-packaging-pom/plugin-config.xml
+++ b/src/test/resources/unit/basic-install-test-packaging-pom/plugin-config.xml
@@ -25,7 +25,7 @@ under the License.
           <project implementation="org.apache.maven.plugin.testing.stubs.MavenProjectStub">
             <file>${basedir}/src/test/resources/unit/basic-install-test-packaging-pom/plugin-config.xml</file>
             <packaging>pom</packaging>
-            <artifact implementation="org.apache.maven.plugins.install.stubs.InstallArtifactStub"/>
+            <artifact implementation="org.apache.maven.plugins.install.stubs.InstallPomArtifactStub"/>
             <attachedArtifacts/>
           </project>
         </configuration>


### PR DESCRIPTION
In general perform a cleanup of plugin, apply updates where needed. The plugin now builds against 3.9.x latest, and minimum is left as is (3.2.5).

A notable change along that above is removal of "baked in" packaging, now plugin relies completely and only on what project and artifact tells, there is no "if this is POM" check anymore. The new "BOM UT" shows this in action. Has to be noted though, that the UT tests ONLY the plugin, to use BOM packaging you need Maven that knows what it is (Maven 3 w/ extension or Maven 4 that has it OOTB).

---

https://issues.apache.org/jira/browse/MINSTALL-197