### PR TITLE
[MINSTALL-207] Change installAtEnd default value

### DIFF
--- a/src/it/MINSTALL-108/verify.groovy
+++ b/src/it/MINSTALL-108/verify.groovy
@@ -20,6 +20,6 @@
 File buildLog = new File( basedir, 'build.log' )
 assert buildLog.exists()
 /* UNTIL MINSTALL-108 will be fixed the result
- * should not be <installAtEnd default-value="false">false</installAtEnd>
+ * should not be <installAtEnd default-value="true">false</installAtEnd>
  */
-assert buildLog.text.contains ( '<installAtEnd default-value="false">true</installAtEnd>')
+assert buildLog.text.contains ( '<installAtEnd default-value="true">true</installAtEnd>')

--- a/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
@@ -67,7 +67,7 @@ public class InstallMojo implements org.apache.maven.api.plugin.Mojo {
      *
      * @since 2.5
      */
-    @Parameter(property = "installAtEnd", defaultValue = "false")
+    @Parameter(property = "installAtEnd", defaultValue = "true")
     private boolean installAtEnd;
 
     /**

--- a/src/test/java/org/apache/maven/plugins/install/InstallMojoPomPackagingTest.java
+++ b/src/test/java/org/apache/maven/plugins/install/InstallMojoPomPackagingTest.java
@@ -37,6 +37,7 @@ import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.di.Singleton;
 import org.apache.maven.api.plugin.Mojo;
 import org.apache.maven.api.plugin.testing.InjectMojo;
+import org.apache.maven.api.plugin.testing.MojoParameter;
 import org.apache.maven.api.plugin.testing.MojoTest;
 import org.apache.maven.api.plugin.testing.stubs.MojoExecutionStub;
 import org.apache.maven.api.plugin.testing.stubs.ProjectStub;
@@ -85,6 +86,7 @@ public class InstallMojoPomPackagingTest {
 
     @Test
     @InjectMojo(goal = "install")
+    @MojoParameter(name = "installAtEnd", value = "false")
     public void testInstallIfPackagingIsPom(InstallMojo mojo) throws Exception {
         assertNotNull(mojo);
         Project project = (Project) getVariableValueFromObject(mojo, "project");

--- a/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/install/InstallMojoTest.java
@@ -39,6 +39,7 @@ import org.apache.maven.api.di.Singleton;
 import org.apache.maven.api.plugin.Mojo;
 import org.apache.maven.api.plugin.MojoException;
 import org.apache.maven.api.plugin.testing.InjectMojo;
+import org.apache.maven.api.plugin.testing.MojoParameter;
 import org.apache.maven.api.plugin.testing.MojoTest;
 import org.apache.maven.api.plugin.testing.stubs.MojoExecutionStub;
 import org.apache.maven.api.plugin.testing.stubs.ProducedArtifactStub;
@@ -95,6 +96,7 @@ public class InstallMojoTest {
 
     @Test
     @InjectMojo(goal = "install")
+    @MojoParameter(name = "installAtEnd", value = "false")
     public void testBasicInstall(InstallMojo mojo) throws Exception {
         assertNotNull(mojo);
         Project project = (Project) getVariableValueFromObject(mojo, "project");
@@ -115,6 +117,7 @@ public class InstallMojoTest {
 
     @Test
     @InjectMojo(goal = "install")
+    @MojoParameter(name = "installAtEnd", value = "false")
     public void testBasicInstallWithAttachedArtifacts(InstallMojo mojo) throws Exception {
         assertNotNull(mojo);
         Project project = (Project) getVariableValueFromObject(mojo, "project");
@@ -145,7 +148,8 @@ public class InstallMojoTest {
         Project project = (Project) getVariableValueFromObject(mojo, "project");
         assertFalse(artifactManager.getPath(project.getMainArtifact().get()).isPresent());
 
-        assertThrows(MojoException.class, mojo::execute, "Did not throw mojo execution exception");
+        MojoException e = assertThrows(MojoException.class, mojo::execute, "Did not throw mojo execution exception");
+        assertEquals("The packaging for this project did not assign a file to the build artifact", e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
JIRA issue: [MINSTALL-207](https://issues.apache.org/jira/browse/MINSTALL-207)

Note that m-deploy-p already has `deployAtEnd=true` [by default](https://github.com/apache/maven-deploy-plugin/blob/master/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java#L68).