### PR TITLE
Build against Maven 4.0.0-rc-5

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,4 +27,3 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
     with:
       maven4-build: true
-      maven4-version: '4.0.0-rc-3' # the same as used in project

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
   <properties>
     <javaVersion>17</javaVersion>
-    <mavenVersion>4.0.0-rc-3</mavenVersion>
+    <mavenVersion>4.0.0-rc-5</mavenVersion>
     <!-- Maven bound -->
     <slf4jVersion>2.0.18</slf4jVersion>
 
@@ -141,6 +141,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-api-model</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-xml</artifactId>
       <version>${mavenVersion}</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
## What & why

`maven-install-plugin` master still pinned the Maven 4 version to
`4.0.0-rc-3` (in `pom.xml` and the CI `maven4-version`). This updates the
plugin to build and test against the current Maven 4 release,
**4.0.0-rc-5**, aligning it with sibling core-4 plugins such as
`maven-clean-plugin`.

## Changes

- Bump `<mavenVersion>` `4.0.0-rc-3` → `4.0.0-rc-5`.
- Add `org.apache.maven:maven-xml` (`provided`). rc-5 introduced the
  `org.apache.maven.api.xml.XmlService` SPI, loaded via `ServiceLoader`.
  The unit-test harness (`MojoExtension`) parses test POMs through
  `MavenStaxReader`, which now requires an `XmlService` implementation;
  without it the unit tests fail with `No XmlService implementation found`.
  `maven-xml` supplies `DefaultXmlService` (mirrors `maven-clean-plugin`).
- Drop the explicit `maven4-version` from `maven-verify.yml` so CI follows
  the shared workflow default (currently `4.0.0-rc-5`) instead of pinning a
  stale RC.

## Verification

`mvn -Prun-its clean verify` on 4.0.0-rc-5: unit tests 14/14 and
integration tests 33/33 green (JDK 17, Temurin).

---

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Run `mvn verify` to make sure basic checks pass.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
