### PR TITLE
Cache projectsUsingPlugin to fix O(N²) reactor scan

### DIFF
--- a/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
@@ -98,6 +98,7 @@ public class InstallMojo implements org.apache.maven.api.plugin.Mojo {
     }
 
     private static final String INSTALL_PROCESSED_MARKER = InstallMojo.class.getName() + ".processed";
+    private static final String PROJECTS_USING_PLUGIN_KEY = InstallMojo.class.getName() + ".projectsUsingPlugin";
 
     public InstallMojo() {}
 
@@ -118,6 +119,26 @@ public class InstallMojo implements org.apache.maven.api.plugin.Mojo {
     private boolean hasState(Project project) {
         Map<String, Object> pluginContext = session.getPluginContext(project);
         return pluginContext.containsKey(INSTALL_PROCESSED_MARKER);
+    }
+
+    /**
+     * Returns the list of reactor projects that have this plugin configured, cached on first call.
+     * The list is invariant during a build and is stored in the current project's plugin
+     * context to avoid recomputing it on every module invocation (O(N) total instead of O(N²)).
+     */
+    @SuppressWarnings("unchecked")
+    private List<Project> getProjectsUsingPlugin() {
+        List<Project> allProjects = session.getProjects();
+        if (allProjects.isEmpty()) {
+            return List.of();
+        }
+        Map<String, Object> ctx = session.getPluginContext(allProjects.get(0));
+        List<Project> cached = (List<Project>) ctx.get(PROJECTS_USING_PLUGIN_KEY);
+        if (cached == null) {
+            cached = allProjects.stream().filter(this::usingPlugin).collect(Collectors.toList());
+            ctx.put(PROJECTS_USING_PLUGIN_KEY, cached);
+        }
+        return cached;
     }
 
     private boolean usingPlugin(Project project) {
@@ -144,8 +165,7 @@ public class InstallMojo implements org.apache.maven.api.plugin.Mojo {
             }
         }
 
-        List<Project> projectsUsingPlugin =
-                session.getProjects().stream().filter(this::usingPlugin).collect(Collectors.toList());
+        List<Project> projectsUsingPlugin = getProjectsUsingPlugin();
         if (allProjectsMarked(projectsUsingPlugin)) {
             for (Project reactorProject : projectsUsingPlugin) {
                 State state = getState(reactorProject);

--- a/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
@@ -133,12 +133,14 @@ public class InstallMojo implements org.apache.maven.api.plugin.Mojo {
             return List.of();
         }
         Map<String, Object> ctx = session.getPluginContext(allProjects.get(0));
-        List<Project> cached = (List<Project>) ctx.get(PROJECTS_USING_PLUGIN_KEY);
-        if (cached == null) {
-            cached = allProjects.stream().filter(this::usingPlugin).collect(Collectors.toList());
-            ctx.put(PROJECTS_USING_PLUGIN_KEY, cached);
+        synchronized (ctx) {
+            List<Project> cached = (List<Project>) ctx.get(PROJECTS_USING_PLUGIN_KEY);
+            if (cached == null) {
+                cached = allProjects.stream().filter(this::usingPlugin).collect(Collectors.toList());
+                ctx.put(PROJECTS_USING_PLUGIN_KEY, cached);
+            }
+            return cached;
         }
-        return cached;
     }
 
     private boolean usingPlugin(Project project) {

--- a/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
+++ b/src/main/java/org/apache/maven/plugins/install/InstallMojo.java
@@ -133,14 +133,9 @@ public class InstallMojo implements org.apache.maven.api.plugin.Mojo {
             return List.of();
         }
         Map<String, Object> ctx = session.getPluginContext(allProjects.get(0));
-        synchronized (ctx) {
-            List<Project> cached = (List<Project>) ctx.get(PROJECTS_USING_PLUGIN_KEY);
-            if (cached == null) {
-                cached = allProjects.stream().filter(this::usingPlugin).collect(Collectors.toList());
-                ctx.put(PROJECTS_USING_PLUGIN_KEY, cached);
-            }
-            return cached;
-        }
+        return (List<Project>) ctx.computeIfAbsent(
+                PROJECTS_USING_PLUGIN_KEY,
+                k -> allProjects.stream().filter(this::usingPlugin).collect(Collectors.toList()));
     }
 
     private boolean usingPlugin(Project project) {


### PR DESCRIPTION
## Summary

- Cache the `projectsUsingPlugin` list in the first reactor project's plugin context on first invocation
- The list is invariant during a build — which projects have the install plugin configured does not change between module invocations
- Reduces O(N²) to O(N) total for the reactor scan

## Problem

`InstallMojo.execute()` computes `session.getProjects().stream().filter(this::usingPlugin).collect(toList())` on **every module invocation**. `usingPlugin()` calls `getPluginsAsMap()` for each project. In a 4383-module reactor, this produces ~19.2M filter evaluations (4383²).

JFR profiling shows this pattern as **5.6% of total CPU time**, all in `PluginContainer.getPluginsAsMap()`.

## Test plan

- [x] All 14 existing tests pass
- [ ] Verify on a large multi-module reactor build

🤖 Generated with [Claude Code](https://claude.com/claude-code)