### PR TITLE
Build against Maven 4.0.0-rc-6

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,3 +27,4 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
       maven4-build: true
+      maven4-version: '4.0.0-rc-6' # the same as used in project

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
   <properties>
     <javaVersion>17</javaVersion>
-    <mavenVersion>4.0.0-rc-5</mavenVersion>
+    <mavenVersion>4.0.0-rc-6</mavenVersion>
     <!-- Maven bound -->
     <slf4jVersion>2.0.18</slf4jVersion>
 


### PR DESCRIPTION
4.0.0-rc-6 is released. This moves `mavenVersion` to it and pins the same version explicitly in the Verify workflow, so CI no longer depends on the `maven4-version` default in maven-gh-actions-shared.

Verified: green on the fork before opening (`Verify` workflow, full matrix).
