### PR TITLE
Pass siteMvn as a String so the site stage runs on Maven 4

### DIFF
--- a/Jenkinsfile.disable
+++ b/Jenkinsfile.disable
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-asfMavenTlpPlgnBuild(jdks:[ "17", "21" ], maven: [ "4.0.x" ], siteJdk:[ "17" ], siteMvn:[ "4.0.x" ])
+asfMavenTlpPlgnBuild(jdks:[ "17", "21" ], maven: [ "4.0.x" ], siteJdk:[ "17" ], siteMvn: "4.0.x" )


### PR DESCRIPTION
`siteMvn` is passed to `doCreateTask` whole, not iterated:

```groovy
def siteMvn = params.containsKey('siteMvn') ? params.siteMvn : '3.9.x'
...
doCreateTask( os, jdk, siteMvn, tasks, first, 'site', taskContext )
```

and `doCreateTask` does `jenkinsEnv.mvnFromVersion(os, "${maven}")`. A Groovy List stringifies to `"[4.0.x]"`, which matches no `case` in `mvnFromVersion` and falls through to `default: return 'maven_3_latest'` — so the site stage has been running on Maven 3 with no error. Passing a String fixes it.

`maven:` is correctly a List — that one *is* iterated (`for (def mvn in mavens)`). Only `siteMvn` has this problem. apache/maven-deploy-plugin already passes it as a String.

Verified by reading the shared library only; a Jenkins pipeline cannot be run locally. Note this does not by itself turn the Jenkins build green — `maven_4_latest` on the build nodes still resolves to 4.0.0-rc-5, so a pom with `<prerequisites>` of rc-6 is rejected either way. This change makes the configuration do what it already says.

This repository's file is `Jenkinsfile.disable`, so nothing runs it today — fixing it here keeps the bug from coming back with the job whenever it is re-enabled.