### PR TITLE
Restore the common wording on the download page

### DIFF
--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -36,7 +36,7 @@ under the License.
       <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
 
       <subsection name="Files">
-        
+
         <p>This is the current stable version of <strong>${project.name}</strong>.</p>
 
         <table>
@@ -51,7 +51,7 @@ under the License.
           <tbody>
             <tr>
               <td>${project.name} ${project.version} (Source zip)</td>
-              <td><a href="[preferred]maven/plugins/${project.artifactId}-${project.version}-source-release.zip">${project.artifactId}-${project.version}-source-release.zip</a></td>
+              <td><a href="https://dlcdn.apache.org/maven/plugins/${project.artifactId}-${project.version}-source-release.zip">${project.artifactId}-${project.version}-source-release.zip</a></td>
               <td><a href="https://downloads.apache.org/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.sha512">${project.artifactId}-${project.version}-source-release.zip.sha512</a></td>
               <td><a href="https://downloads.apache.org/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.asc">${project.artifactId}-${project.version}-source-release.zip.asc</a></td>
             </tr>
@@ -72,4 +72,3 @@ under the License.
     </section>
   </body>
 </document>
-


### PR DESCRIPTION
Ports #436 to the 3.x line, which it missed.

Gen2→Gen3 on this page is href-only — the `Files` subsection already exists here, so no anchor changes and no text changes.

Verified: before/after `mvn site` → rendered `download.html` differs by exactly the one href, plus Doxia adding `class="externalLink"`.